### PR TITLE
Update requestTranscription to use file buffer

### DIFF
--- a/backend/src/services/Transcript/transcribeMP3Service.ts
+++ b/backend/src/services/Transcript/transcribeMP3Service.ts
@@ -95,9 +95,9 @@ const requestTranscription = async (filePath: string, fileName: string) => {
   }
 
   try {
-    const fileStream = fs.createReadStream(filePath);
+    const fileBuffer = await fs.promises.readFile(filePath);
     const formData = new FormData();
-    formData.append("file", fileStream, fileName);
+    formData.append("file", fileBuffer, fileName);
     formData.append("model", "whisper-1");
     formData.append("language", "en");
 


### PR DESCRIPTION
Change the `requestTranscription` function to utilize a file buffer instead of a stream for improved handling of file uploads.