### PR TITLE
LLM repo abilities

### DIFF
--- a/backend/src/controllers/mingoAgentController.ts
+++ b/backend/src/controllers/mingoAgentController.ts
@@ -46,7 +46,7 @@ class mingoAgentController extends baseController {
         req.user?._id,
         typeof transcript === "string" ? transcript : undefined,
       );
-      res.json({ reply: result.reply });
+      res.json({ reply: result.reply, taskActionPerformed: result.taskActionPerformed });
     } catch (err) {
       console.error(err);
       res.status(500).send("Error: Can't generate reply for the meeting");

--- a/backend/src/services/LLM/mingoAgentService.ts
+++ b/backend/src/services/LLM/mingoAgentService.ts
@@ -26,7 +26,18 @@ type AgentReply = {
   chat: any;
   reply: string;
   messages: ChatMessage[];
+  taskActionPerformed: boolean;
 };
+
+type TaskAction =
+  | { type: "create"; title: string; description: string }
+  | { type: "close"; issueNumber: number }
+  | { type: "reopen"; issueNumber: number }
+  | { type: "assign"; issueNumber: number; assignee: string }
+  | { type: "rename"; issueNumber: number; title: string }
+  | { type: "delete"; issueNumber: number };
+
+type TaskActionResult = { success: boolean; description: string };
 
 type RetrievalScope =
   | "current_meeting"
@@ -815,6 +826,344 @@ class MingoAgentService {
     return `I couldn't reach the model, but the available context for ${meetingTitle} is still limited.`;
   }
 
+  // ── Task action detection ─────────────────────────────────────
+
+  private async detectTaskAction(
+    userMessage: string,
+    taskFacts: TaskFactSummary,
+    repoName: string,
+  ): Promise<TaskAction | null> {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) return null;
+
+    const taskList = taskFacts.tasks.length
+      ? taskFacts.tasks
+          .map(
+            (t) =>
+              `- #${t.issueNumber ?? "?"} "${t.title}" (${t.status})${t.assignee ? ` assignee=${t.assignee}` : ""}`,
+          )
+          .join("\n")
+      : "No tasks available.";
+
+    const systemPrompt = [
+      "You are a task-command classifier for a meeting assistant.",
+      "Decide whether the user message is a task management command.",
+      `Repository in context: ${repoName || "unknown"}.`,
+      "If the message is a command, return JSON matching exactly one of these shapes:",
+      '  {"action":"create","title":"...","description":"..."}',
+      '  {"action":"close","issueNumber":number}',
+      '  {"action":"reopen","issueNumber":number}',
+      '  {"action":"assign","issueNumber":number,"assignee":"githubUsername"}',
+      '  {"action":"rename","issueNumber":number,"title":"new title"}',
+      '  {"action":"delete","issueNumber":number}',
+      "Use 'delete' when the user says delete, remove, or get rid of a task/issue.",
+      "Use 'close' when the user says close, complete, or mark as done.",
+      "If the message is NOT a task command, return: {\"action\":null}",
+      "Return ONLY valid JSON. No prose, no markdown.",
+      "",
+      "Current tasks for reference:",
+      taskList,
+    ].join("\n");
+
+    try {
+      const response = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "gpt-4o-mini",
+          temperature: 0,
+          max_tokens: 150,
+          response_format: { type: "json_object" },
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userMessage },
+          ],
+        }),
+      });
+
+      if (!response.ok) return null;
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const raw = data.choices?.[0]?.message?.content?.trim() ?? "";
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+      if (!parsed.action || parsed.action === null) return null;
+
+      const action = String(parsed.action);
+
+      if (action === "create") {
+        const title = typeof parsed.title === "string" ? parsed.title.trim() : "";
+        if (!title) return null;
+        return {
+          type: "create",
+          title,
+          description: typeof parsed.description === "string" ? parsed.description.trim() : "",
+        };
+      }
+
+      const issueNumber =
+        typeof parsed.issueNumber === "number"
+          ? parsed.issueNumber
+          : Number(parsed.issueNumber);
+
+      if (!Number.isFinite(issueNumber) || issueNumber <= 0) return null;
+
+      if (action === "close") return { type: "close", issueNumber };
+      if (action === "reopen") return { type: "reopen", issueNumber };
+      if (action === "delete") return { type: "delete", issueNumber };
+
+      if (action === "assign") {
+        const assignee = typeof parsed.assignee === "string" ? parsed.assignee.trim() : "";
+        if (!assignee) return null;
+        return { type: "assign", issueNumber, assignee };
+      }
+
+      if (action === "rename") {
+        const title = typeof parsed.title === "string" ? parsed.title.trim() : "";
+        if (!title) return null;
+        return { type: "rename", issueNumber, title };
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveRepoFullName(authorization: string, repoName: string): Promise<string> {
+    if (repoName.includes("/")) return repoName;
+    try {
+      const repos = await this.fetchGitHubJson<Array<{ name: string; full_name: string }>>(
+        "https://api.github.com/user/repos?sort=updated&per_page=100",
+        authorization,
+      );
+      const match = repos?.find(
+        (r) => r.name.trim().toLowerCase() === repoName.trim().toLowerCase(),
+      );
+      return match?.full_name ?? repoName;
+    } catch {
+      return repoName;
+    }
+  }
+
+  private async patchGitHubIssue(
+    authorization: string,
+    repoFullName: string,
+    issueNumber: number,
+    patch: Record<string, unknown>,
+  ): Promise<{ number: number; title?: string; state?: string; html_url?: string } | null> {
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${repoFullName}/issues/${issueNumber}`,
+        {
+          method: "PATCH",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: authorization,
+            "Content-Type": "application/json",
+            "User-Agent": "Mingo",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify(patch),
+        },
+      );
+      if (!response.ok) return null;
+      return (await response.json()) as {
+        number: number;
+        title?: string;
+        state?: string;
+        html_url?: string;
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async createGitHubIssue(
+    authorization: string,
+    repoFullName: string,
+    title: string,
+    body?: string,
+  ): Promise<{ number: number; html_url?: string } | null> {
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${repoFullName}/issues`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: authorization,
+            "Content-Type": "application/json",
+            "User-Agent": "Mingo",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({ title, body: body || "" }),
+        },
+      );
+      if (!response.ok) return null;
+      return (await response.json()) as { number: number; html_url?: string };
+    } catch {
+      return null;
+    }
+  }
+
+  private async executeTaskAction(
+    action: TaskAction,
+    meeting: any,
+    userId?: string,
+  ): Promise<TaskActionResult> {
+    const repoName: string =
+      typeof meeting?.gitHubRepoName === "string" ? meeting.gitHubRepoName.trim() : "";
+
+    if (!repoName) {
+      return { success: false, description: "No GitHub repository is linked to this meeting." };
+    }
+
+    if (!userId) {
+      return { success: false, description: "User not authenticated." };
+    }
+
+    const user = await this.users.findById(userId);
+    const authorization = this.getGitHubAuthorization(user);
+
+    if (!authorization) {
+      return {
+        success: false,
+        description: "GitHub account is not connected. Go to Settings to link your account.",
+      };
+    }
+
+    const repoFullName = await this.resolveRepoFullName(authorization, repoName);
+
+    if (action.type === "create") {
+      const issue = await this.createGitHubIssue(
+        authorization,
+        repoFullName,
+        action.title,
+        action.description,
+      );
+      if (!issue) {
+        return { success: false, description: `Failed to create issue in ${repoFullName}.` };
+      }
+      // Also persist locally so the meeting task list picks it up.
+      try {
+        const task = await this.tasks.create({
+          title: action.title,
+          description: action.description,
+          status: "To Do",
+          gitHubIssueId: issue.number,
+          gitHubRepoName: repoFullName,
+          gitHubRepoOwner: userId,
+        });
+        if (Array.isArray(meeting.tasks)) {
+          meeting.tasks.push(task._id);
+          await this.meetings.findByIdAndUpdate(meeting._id, { $push: { tasks: task._id } });
+        }
+      } catch {
+        // Local persistence is best-effort; the GitHub issue was created successfully.
+      }
+      return {
+        success: true,
+        description: `Created GitHub issue #${issue.number} "${action.title}" in ${repoFullName}.${issue.html_url ? ` URL: ${issue.html_url}` : ""}`,
+      };
+    }
+
+    if (action.type === "close") {
+      const result = await this.patchGitHubIssue(authorization, repoFullName, action.issueNumber, {
+        state: "closed",
+      });
+      if (!result) {
+        return {
+          success: false,
+          description: `Failed to close issue #${action.issueNumber} in ${repoFullName}.`,
+        };
+      }
+      return {
+        success: true,
+        description: `Closed issue #${action.issueNumber} "${result.title ?? ""}" in ${repoFullName}.`,
+      };
+    }
+
+    if (action.type === "reopen") {
+      const result = await this.patchGitHubIssue(authorization, repoFullName, action.issueNumber, {
+        state: "open",
+      });
+      if (!result) {
+        return {
+          success: false,
+          description: `Failed to reopen issue #${action.issueNumber} in ${repoFullName}.`,
+        };
+      }
+      return {
+        success: true,
+        description: `Reopened issue #${action.issueNumber} "${result.title ?? ""}" in ${repoFullName}.`,
+      };
+    }
+
+    if (action.type === "assign") {
+      const result = await this.patchGitHubIssue(authorization, repoFullName, action.issueNumber, {
+        assignees: [action.assignee],
+      });
+      if (!result) {
+        return {
+          success: false,
+          description: `Failed to assign issue #${action.issueNumber} to ${action.assignee}.`,
+        };
+      }
+      return {
+        success: true,
+        description: `Assigned issue #${action.issueNumber} "${result.title ?? ""}" to @${action.assignee} in ${repoFullName}.`,
+      };
+    }
+
+    if (action.type === "rename") {
+      const result = await this.patchGitHubIssue(authorization, repoFullName, action.issueNumber, {
+        title: action.title,
+      });
+      if (!result) {
+        return {
+          success: false,
+          description: `Failed to rename issue #${action.issueNumber}.`,
+        };
+      }
+      return {
+        success: true,
+        description: `Renamed issue #${action.issueNumber} to "${action.title}" in ${repoFullName}.`,
+      };
+    }
+
+    if (action.type === "delete") {
+      // Remove any local task record that mirrors this GitHub issue.
+      try {
+        await this.tasks.findOneAndDelete({ gitHubIssueId: action.issueNumber });
+      } catch {
+        // Best-effort — proceed even if local record is missing.
+      }
+
+      // GitHub REST API does not support true issue deletion; close instead.
+      const result = await this.patchGitHubIssue(authorization, repoFullName, action.issueNumber, {
+        state: "closed",
+      });
+      if (!result) {
+        return {
+          success: false,
+          description: `Failed to delete issue #${action.issueNumber} in ${repoFullName}.`,
+        };
+      }
+      return {
+        success: true,
+        description: `Deleted issue #${action.issueNumber} "${result.title ?? ""}" from ${repoFullName}. The local record has been removed. Note: GitHub does not allow full issue deletion via the API, so the issue has been closed on GitHub.`,
+      };
+    }
+
+    return { success: false, description: "Unknown action." };
+  }
+
   private buildFallbackSummary(meeting: any) {
     const meetingTitle =
       typeof meeting?.title === "string" && meeting.title.trim()
@@ -1212,6 +1561,7 @@ class MingoAgentService {
     history: ChatMessage[],
     userMessage: string,
     transcript?: string,
+    actionResult?: TaskActionResult,
   ) {
     const transcriptSection = transcript?.trim()
       ? ["", "Meeting transcript (verbatim audio transcription):", transcript.trim().slice(0, 6000)]
@@ -1287,6 +1637,15 @@ class MingoAgentService {
       "Recent chat history:",
       this.serializeHistory(history),
       "",
+      ...(actionResult
+        ? [
+            actionResult.success
+              ? `Task action executed successfully: ${actionResult.description}`
+              : `Task action failed: ${actionResult.description}`,
+            "Inform the user of this result naturally in your reply. Do not repeat the raw description verbatim — rephrase it conversationally.",
+            "",
+          ]
+        : []),
       `User message: ${userMessage}`,
       "",
       "Answer as Mingo:",
@@ -1401,17 +1760,26 @@ class MingoAgentService {
       timestamp: new Date(),
     };
 
-    const retrievalPlan = await this.buildRetrievalPlan(
-      meeting,
-      recentHistory,
-      normalizedMessage,
-    );
+    const primaryTaskFacts = await this.loadTaskFactsForMeeting(meeting, userId);
+
+    const repoName: string =
+      typeof meeting?.gitHubRepoName === "string" ? meeting.gitHubRepoName.trim() : "";
+
+    const [retrievalPlan, detectedAction] = await Promise.all([
+      this.buildRetrievalPlan(meeting, recentHistory, normalizedMessage),
+      this.detectTaskAction(normalizedMessage, primaryTaskFacts, repoName),
+    ]);
+
+    let actionResult: TaskActionResult | undefined;
+    if (detectedAction) {
+      actionResult = await this.executeTaskAction(detectedAction, meeting, userId);
+    }
+
     const relatedMeetings = await this.findRelevantMeetings(
       userId,
       meeting,
       retrievalPlan,
     );
-    const primaryTaskFacts = await this.loadTaskFactsForMeeting(meeting, userId);
     const relatedTaskFacts = await Promise.all(
       relatedMeetings.map((relatedMeeting) =>
         this.loadTaskFactsForMeeting(relatedMeeting, userId),
@@ -1427,6 +1795,7 @@ class MingoAgentService {
       recentHistory,
       normalizedMessage,
       transcript,
+      actionResult,
     );
 
     let reply = "";
@@ -1474,6 +1843,7 @@ class MingoAgentService {
       chat,
       reply,
       messages: updatedMessages,
+      taskActionPerformed: Boolean(actionResult?.success),
     };
   }
 

--- a/frontend/src/pages/MeetingPage.css
+++ b/frontend/src/pages/MeetingPage.css
@@ -1,12 +1,20 @@
 .meeting-page {
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   background: #f8fafc;
 }
 
 .meeting-page__main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   max-width: 1320px;
+  width: 100%;
   margin: 0 auto;
-  padding: 32px 44px 48px;
+  padding: 32px 44px 24px;
 }
 
 /* ── Hero ───────────────────────────────────────────────────── */
@@ -376,10 +384,12 @@
 
 /* ── Content grid ───────────────────────────────────────────── */
 .meeting-content {
+  flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-columns: 1.04fr 1fr;
   gap: 16px;
-  align-items: start;
+  align-items: stretch;
 }
 
 .meeting-chat-card,
@@ -392,7 +402,7 @@
 }
 
 .meeting-chat-card {
-  min-height: 620px;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -421,6 +431,8 @@
 
 .meeting-chat-card__body {
   flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: 20px 16px 16px;
   display: flex;
   flex-direction: column;
@@ -544,12 +556,22 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+.meeting-side .meeting-card:last-child {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .meeting-tasks {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  max-height: 320px;
   overflow-y: auto;
 }
 
@@ -894,6 +916,25 @@
   background: #e0e7ff;
 }
 
+.meeting-tasks-refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.meeting-tasks-refresh svg {
+  width: 13px;
+  height: 13px;
+}
+
+.meeting-tasks-refresh--spinning svg {
+  animation: meeting-tasks-spin 0.8s linear infinite;
+}
+
+@keyframes meeting-tasks-spin {
+  to { transform: rotate(360deg); }
+}
+
 .meeting-transcript-btn--save {
   background: #4f46e5;
   color: #fff;
@@ -962,6 +1003,99 @@
   color: #dc2626;
   font-size: 12px;
   font-weight: 600;
+}
+
+/* ── Mingo help button & tooltip ────────────────────────────── */
+.mingo-help {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.mingo-help__btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1.5px solid #c7d2fe;
+  background: #eef2ff;
+  color: #6366f1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.mingo-help__btn:hover {
+  background: #e0e7ff;
+  border-color: #818cf8;
+  color: #4f46e5;
+}
+
+.mingo-help__btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mingo-help__tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 200;
+  width: 300px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(15, 23, 42, 0.13);
+  padding: 14px 16px;
+}
+
+.mingo-help:hover .mingo-help__tooltip,
+.mingo-help__btn:focus + .mingo-help__tooltip {
+  display: block;
+}
+
+.mingo-help__tooltip strong {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 10px;
+}
+
+.mingo-help__tooltip ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.mingo-help__tooltip li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12.5px;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.mingo-help__icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.mingo-help__tooltip em {
+  display: block;
+  font-size: 11.5px;
+  color: #94a3b8;
+  font-style: normal;
+  margin-top: 1px;
 }
 
 /* ── Suggested Tasks card ───────────────────────────────────── */

--- a/frontend/src/pages/MeetingPage.tsx
+++ b/frontend/src/pages/MeetingPage.tsx
@@ -289,61 +289,60 @@ const MeetingPage = () => {
   const [emailError, setEmailError] = useState('');
   const [tasks, setTasks] = useState<Task[]>([]);
   const [taskUpdateError, setTaskUpdateError] = useState('');
+  const [isRefreshingTasks, setIsRefreshingTasks] = useState(false);
+
+  const loadTasks = async (silent = false) => {
+    const meetingId =
+      meetingIdRef.current ||
+      parsedDraft?.id ||
+      localStorage.getItem('currentMeetingId') ||
+      '';
+
+    const repo = parsedDraft?.gitHubRepoName || repositoryLabel;
+    const user = JSON.parse(localStorage.getItem('user') || '{}');
+    const userId = user.id || user._id;
+
+    if (!userId || !repo) return;
+
+    if (!silent) setIsRefreshingTasks(true);
+
+    try {
+      const response = await fetchWithAuth(
+        `/api/users/${userId}/tasks?repo=${encodeURIComponent(repo)}`
+      );
+
+      if (!response.ok) throw new Error('Failed to load tasks');
+
+      const data = await response.json();
+
+      const backendTasks = (data.tasks || data || []).map(
+        (task: any, index: number) => ({
+          id: String(task.id || task._id || Date.now() + index),
+          meetingId: task.meeting?._id,
+          title: task.title || task.description || 'Untitled task',
+          assignee: task.assignee || task.assigneeName || task.owner || 'Unassigned',
+          due: task.due || task.dueDate || 'No due date',
+          tag: task.tag || task.jiraKey || `TASK-${task.gitHubIssueId || index + 1}`,
+          htmlUrl: task.htmlUrl || task.html_url || '',
+          source: task.source === 'github' ? 'github' : 'local',
+          gitHubIssueId: task.gitHubIssueId,
+          gitHubRepoName: task.gitHubRepoName || repo,
+          done:
+            typeof task.status === 'string' &&
+            task.status.toLowerCase() === 'done',
+        })
+      );
+
+      if (backendTasks.length > 0) setTasks(backendTasks);
+    } catch (error) {
+      console.error('Failed to load tasks:', error);
+    } finally {
+      if (!silent) setIsRefreshingTasks(false);
+    }
+  };
 
   useEffect(() => {
-    const loadTasks = async () => {
-
-      const meetingId =
-        meetingIdRef.current ||
-        parsedDraft?.id ||
-        localStorage.getItem('currentMeetingId') ||
-        '';
-
-      const repo = parsedDraft?.gitHubRepoName || repositoryLabel;
-
-      const user = JSON.parse(localStorage.getItem('user') || '{}');
-      const userId = user.id || user._id;
-
-      if (!userId || !repo) return;
-
-      try {
-        const response = await fetchWithAuth(
-          `/api/users/${userId}/tasks?repo=${encodeURIComponent(repo)}`
-        );
-
-        if (!response.ok) {
-          throw new Error('Failed to load tasks');
-        }
-
-        const data = await response.json();
-
-        const backendTasks = (data.tasks || data || []).map(
-          (task: any, index: number) => ({
-            id: String(task.id || task._id || Date.now() + index),
-            meetingId: task.meeting?._id,
-            title: task.title || task.description || 'Untitled task',
-            assignee: task.assignee || task.assigneeName || task.owner || 'Unassigned',
-            due: task.due || task.dueDate || 'No due date',
-            tag: task.tag || task.jiraKey || `TASK-${task.gitHubIssueId || index + 1}`,
-            htmlUrl: task.htmlUrl || task.html_url || '',
-            source: task.source === 'github' ? 'github' : 'local',
-            gitHubIssueId: task.gitHubIssueId,
-            gitHubRepoName: task.gitHubRepoName || repo,
-            done:
-              typeof task.status === 'string' &&
-              task.status.toLowerCase() === 'done',
-          })
-        );
-
-        if (backendTasks.length > 0) {
-          setTasks(backendTasks);
-        }
-      } catch (error) {
-        console.error('Failed to load tasks:', error);
-      }
-    };
-
-    loadTasks();
+    void loadTasks(true);
   }, []);
 
   const completedTasks = tasks.filter((task) => task.done);
@@ -404,6 +403,10 @@ const MeetingPage = () => {
           text: data.reply || 'No response from AI',
         },
       ]);
+
+      if (data.taskActionPerformed) {
+        void loadTasks(true);
+      }
     } catch (error) {
       console.error(error);
 
@@ -656,10 +659,44 @@ const MeetingPage = () => {
 
         <section className="meeting-content">
           <article className="meeting-chat-card">
-            <header className="meeting-card__header">
+            <header className="meeting-card__header meeting-card__header--with-action">
               <h2>
                 Chat with <span>Mingo</span>
               </h2>
+              <div className="mingo-help">
+                <button type="button" className="mingo-help__btn" aria-label="What can Mingo do?">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10" />
+                    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                    <circle cx="12" cy="17" r="0.5" fill="currentColor" />
+                  </svg>
+                </button>
+                <div className="mingo-help__tooltip" role="tooltip">
+                  <strong>What Mingo can do</strong>
+                  <ul>
+                    <li>
+                      <span className="mingo-help__icon">✅</span>
+                      <span><b>Tasks</b> — create, close, reopen, rename, assign, or delete GitHub issues<br /><em>e.g. "Create a task to fix the login bug"</em></span>
+                    </li>
+                    <li>
+                      <span className="mingo-help__icon">📄</span>
+                      <span><b>Transcript</b> — answer questions based on the uploaded MP3 transcription</span>
+                    </li>
+                    <li>
+                      <span className="mingo-help__icon">🔍</span>
+                      <span><b>Repo &amp; issues</b> — ask about open issues, assignees, or status in your linked repo</span>
+                    </li>
+                    <li>
+                      <span className="mingo-help__icon">📋</span>
+                      <span><b>Meeting context</b> — recap decisions, action items, and participants</span>
+                    </li>
+                    <li>
+                      <span className="mingo-help__icon">🕘</span>
+                      <span><b>Past meetings</b> — reference previous meetings for comparison or follow-ups</span>
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </header>
 
             <div className="meeting-chat-card__body">
@@ -814,8 +851,21 @@ const MeetingPage = () => {
             )}
 
             <article className="meeting-card">
-              <header className="meeting-card__header">
+              <header className="meeting-card__header meeting-card__header--with-action">
                 <h2>Tasks</h2>
+                <button
+                  type="button"
+                  className={`meeting-transcript-btn meeting-transcript-btn--edit meeting-tasks-refresh${isRefreshingTasks ? ' meeting-tasks-refresh--spinning' : ''}`}
+                  onClick={() => void loadTasks(false)}
+                  disabled={isRefreshingTasks}
+                  aria-label="Refresh tasks"
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="23 4 23 10 17 10" />
+                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                  </svg>
+                  {isRefreshingTasks ? 'Refreshing…' : 'Refresh'}
+                </button>
               </header>
 
               <div className="meeting-tasks">


### PR DESCRIPTION
Meeting Page — UX, LLM capabilities & task management improvements
Suggested Tasks in Meeting Page

Suggested tasks from the MP3 upload modal are now passed via localStorage to the Meeting Page and displayed below the Transcript card with checkboxes and a "Create Tasks" button.
LLM Chat — Transcript context

The Mingo Agent chat now receives the uploaded MP3 transcript as context on every message, enabling it to answer questions about what was discussed.
LLM Chat — GitHub Task Actions

Mingo can now create, close, reopen, rename, assign, and delete GitHub issues directly from the chat using natural language (e.g. "Create a task to fix the login bug", "Close #12", "Delete #5"). Uses OpenAI intent classification + GitHub REST API. Local task records are updated accordingly.
Task list auto-refresh + manual refresh

After Mingo performs a task action, the backend returns taskActionPerformed: true and the task list silently refreshes. A manual Refresh button was also added to the Tasks card header.
Mingo help tooltip

A ? button in the chat header reveals a tooltip describing all of Mingo's capabilities.
Meeting Page layout overhaul

Page is now viewport-locked (height: 100vh; overflow: hidden)
Chat messages scroll inside the chat card; input bar stays pinned at the bottom
Sidebar (transcript, tasks) scrolls independently — never pushed offscreen
Chat and Tasks cards are the same height

Meeting Summary modal fixes

Background page no longer scrolls while the summary modal is open
Action buttons are always reachable (modal scrolls internally)

Tasks Page scroll fix

Heading, stats, and controls stay pinned; only the task list scrolls.